### PR TITLE
Fix regression / syntax error for Python 2.7

### DIFF
--- a/zipp.py
+++ b/zipp.py
@@ -237,7 +237,7 @@ class Path:
         self.root = FastLookup.make(root)
         self.at = at
 
-    def open(self, mode='r', *args, pwd=None, **kwargs):
+    def open(self, mode='r', pwd=None, *args, **kwargs):
         """
         Open this entry as text or binary following the semantics
         of ``pathlib.Path.open()`` by passing arguments through


### PR DESCRIPTION
Fix regression / syntax error for Python 2.7 introduced on commit https://github.com/jaraco/zipp/commit/3d17ee58654a24e8578f7979d7019e0f41ca060b

```
  File "/home/fox/git/botoform/.env/lib/python2.7/site-packages/importlib_resources-3.3.0-py2.7.egg/importlib_resources/_compat.py", line 48, in <module>
    from zipp import Path as ZipPath  # type: ignore
  File "/home/fox/git/botoform/.env/lib/python2.7/site-packages/zipp-3.4.0-py2.7.egg/zipp.py", line 240
    def open(self, mode='r', *args, pwd=None, **kwargs):
                                      ^
SyntaxError: invalid syntax
```